### PR TITLE
add support for other name attributes (salutation, etc.)

### DIFF
--- a/spec/util-spec.coffee
+++ b/spec/util-spec.coffee
@@ -6,22 +6,23 @@ describe 'Utility functions', ->
   describe 'parseFullname', ->
 
     it 'should parse a standard name', ->
-      [firstName, lastName] = utils.parseFullname("John Smith")
-      assert.equal firstName, "John"
-      assert.equal lastName, "Smith"
+      parsed = utils.parseFullname("John Smith")
+      assert.equal parsed.first_name, "John"
+      assert.equal parsed.last_name, "Smith"
 
     it 'should parse a name with an apostrophe', ->
-      [firstName, lastName] = utils.parseFullname("Sean O'Reilly")
-      assert.equal firstName, "Sean"
-      assert.equal lastName, "O'Reilly"
+      parsed = utils.parseFullname("Sean O'Reilly")
+      assert.equal parsed.first_name, "Sean"
+      assert.equal parsed.last_name, "O'Reilly"
 
     it 'should parse a name with a space', ->
-      [firstName, lastName] = utils.parseFullname("Juliana de Luna")
-      assert.equal firstName, "Juliana"
-      assert.equal lastName, "de Luna"
+      parsed = utils.parseFullname("Juliana de Luna")
+      assert.equal parsed.first_name, "Juliana"
+      assert.equal parsed.last_name, "de Luna"
 
     it 'should parse a name with a bunch of other stuff', ->
-      [firstName, lastName] = utils.parseFullname("Mr. Charles P. Wooten, III")
-      assert.equal firstName, "Charles"
-      assert.equal lastName, "Wooten"
-
+      parsed = utils.parseFullname("Mr. Charles P. Wooten, III")
+      assert.equal parsed.salutation, "Mr."
+      assert.equal parsed.first_name, "Charles"
+      assert.equal parsed.middle_name, "P."
+      assert.equal parsed.last_name, "Wooten"

--- a/src/util.coffee
+++ b/src/util.coffee
@@ -3,7 +3,12 @@ humanname = require 'humanname'
 # given a string containing a person's full name, return a two-element array containing firstName and lastName
 parseFullname = (fullname) ->
   parsed = humanname.parse(fullname)
-  [ parsed.firstName, parsed.lastName ]
+
+  salutation: parsed.salutation
+  first_name: parsed.firstName
+  middle_name: parsed.initials
+  last_name: parsed.lastName
+  suffix: parsed.suffix
 
 
 module.exports =


### PR DESCRIPTION
Should have done it this way to start, instead of returning an array. It's a breaking change but there's zero usage yet so I don't plan to bump the major package version.

Fixes #4. 