### PR TITLE
fix calculateTimeout to not return 0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
   - 4
-  - 5
+  - 6
+  - node
 sudo: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.4.1] - 2016-11-08
+### Fixed
+- fixed `calculateTimeout()` to return minimum of 1 (not 0)
+
 ## [0.4.0] - 2016-10-31
 ### Added
 - Added utility function `calculateTimeout()`

--- a/spec/util-spec.coffee
+++ b/spec/util-spec.coffee
@@ -106,4 +106,4 @@ describe 'Utility functions', ->
       timeout = -1
       start = new Date(new Date().getTime() - 2000) # 2s ago
       timeout = utils.calculateTimeout(start, 1000) # 1s timeout
-      assert.equal timeout, 0
+      assert.equal timeout, 1

--- a/src/util.coffee
+++ b/src/util.coffee
@@ -38,8 +38,9 @@ module.exports =
       throw new HttpError(415, {'Content-Type': 'text/plain'}, "MIME type in Content-Type header is not supported. Use only #{mimeTypes.join ', '}")
 
 
+  # given a starting timestamp and the total timeout (in ms), return the remaining timeout (in ms)
   calculateTimeout: (startTimestamp, timeoutMs) ->
     elapsedMs = new Date().getTime() - startTimestamp
     remaining = timeoutMs - elapsedMs
-    return 0 if remaining <= 0
+    return 1 if remaining <= 0 # the `request` library treats a timeout value of '0' as no timeout
     remaining


### PR DESCRIPTION
While working on the Datamyx integration's build errors, I found that giving the `request` library a timeout value of `0` results in the library never timing out. This isn't documented anywhere that I could find, but was true in my own tests (which tested requests up to 5 minutes). 