### PR TITLE
add stripMetadata helper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - 4
-  - 6
+  - 8
   - node
 sudo: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.5.0] - 2019-02-28
+### Added
+- added `stripMetadata()` to strip non-lead, non-appended data from `vars`
+
 ## [0.4.1] - 2016-11-08
 ### Fixed
 - fixed `calculateTimeout()` to return minimum of 1 (not 0)

--- a/package.json
+++ b/package.json
@@ -7,9 +7,6 @@
     "type": "git",
     "url": "https://github.com/activeprospect/leadconduit-integration.git"
   },
-  "engines": {
-    "node": ">=0.10.0"
-  },
   "scripts": {
     "test": "cake test",
     "prepublish": "cake build"
@@ -24,6 +21,6 @@
   "devDependencies": {
     "chai": ">= 1.9.0",
     "coffee-script": ">= 1.7.0",
-    "leadconduit-cakefile": "^0.1.0"
+    "leadconduit-cakefile": "^0.3.3"
   }
 }

--- a/spec/http-error-spec.coffee
+++ b/spec/http-error-spec.coffee
@@ -13,7 +13,7 @@ describe 'HttpError', ->
     catch e
       stack = e.stack.split('\n')
       assert.equal stack[0], 'HttpError: integration terminated early'
-      assert.match stack[1], /spec\/http\-error\-spec\.coffee\:9\:17\)$/
+      assert.match stack[1], /at fxn.*spec\/http\-error\-spec\.coffee\:/
 
   it 'should have name', ->
     assert.equal new HttpError(500, {}, '').name, 'HttpError'

--- a/spec/stripMetadata-spec.coffee
+++ b/spec/stripMetadata-spec.coffee
@@ -1,0 +1,86 @@
+assert = require('chai').assert
+types = require('leadconduit-types')
+strip = require('../src/stripMetadata')
+
+describe 'Strip metadata', ->
+
+  beforeEach () ->
+    @vars =
+      submission:
+        timestamp: '2019-02-27T08:02:53.669Z'
+      account:
+        id: 'account123'
+        name: 'Lead Garden, Inc.'
+        sso_id: 'sso123'
+      flow:
+        id: 'flow123'
+        name: 'Sales Leads'
+      random: 24
+      source:
+        id: 'source123'
+        name: 'Contact Form'
+      lead:
+        id: 'lead123'
+        email: types.email.parse('dee@leadgarden.com')
+        first_name: 'Dee'
+        last_name: 'Daniels'
+        phone_1: types.phone.parse('512-555-1212')
+        trustedform_cert_url: types.url.parse('https://cert.trustedform.com/cert123')
+      suppression_list:
+        query_item:
+          key: 'dee@leadgarden.com'
+          found: types.boolean.parse(false)
+          reason: null
+          outcome: 'success'
+          duration: types.number.parse(0.0123)
+          specified_lists: ['sales_leads']
+        add_item:
+          reason: null
+          outcome: 'success'
+          accepted: types.number.parse(1)
+          rejected: types.number.parse(0)
+          duration: types.number.parse(0.0456)
+      anura:
+        outcome: 'success'
+        billable: types.number.parse(1)
+        is_suspect: types.boolean.parse(false)
+
+
+  it 'should strip basic metadata', ->
+    expected =
+      email: 'dee@leadgarden.com'
+      first_name: 'Dee'
+      last_name: 'Daniels'
+      phone_1: '5125551212'
+      trustedform_cert_url: 'https://cert.trustedform.com/cert123'
+      suppression_list:
+        query_item:
+          key: 'dee@leadgarden.com'
+          found: false
+          duration: 0.0123
+          specified_lists: ['sales_leads']
+        add_item:
+          accepted: 1
+          rejected: 0
+          duration: 0.0456
+      anura:
+        is_suspect: false
+
+    assert.deepEqual(strip(@vars), expected)
+
+
+  it 'should strip basic metadata plus additional fields', ->
+    expected =
+      email: 'dee@leadgarden.com'
+      first_name: 'Dee'
+      last_name: 'Daniels'
+      phone_1: '5125551212'
+      trustedform_cert_url: 'https://cert.trustedform.com/cert123'
+      suppression_list:
+        add_item:
+          accepted: 1
+          rejected: 0
+      anura:
+        is_suspect: false
+
+    assert.deepEqual(strip(@vars, ['query_item.*', '.*.duration']), expected)

--- a/src/stripMetadata.coffee
+++ b/src/stripMetadata.coffee
@@ -1,0 +1,33 @@
+_ = require('lodash')
+flat = require('flat')
+
+excludePatterns = [
+  /^timestamp$/
+  /^timeout_seconds$/
+  /^random$/
+  /^flow\./
+  /^source\./
+  /^account\./
+  /^lead\.id/
+  /^recipient\./
+  /^submission\./
+  /\.outcome$/
+  /\.reason$/
+  /\.billable$/
+]
+
+# given the `vars` "snowball", this will strip all the data that a user
+# wouldn't want delivered as a "lead". used, for example, by email-delivery
+module.exports = (vars, additionalExcludes = []) ->
+
+  for exclude in additionalExcludes
+    excludePatterns.push RegExp(exclude)
+
+  stripped = {}
+  flatVars = flat.flatten(vars)
+  for key of flatVars
+    if !excludePatterns.some((val) => key.match(val))
+      # replace attribute, moving "lead." fields up a level
+      _.set stripped, key.replace(/^lead./, ''), flatVars[key]?.valueOf()
+
+  stripped


### PR DESCRIPTION
Exctracted functionality from `email-delivery` to strip metadata from a lead (i.e., the attributes in the `vars` lead snowball that a customer wouldn't care to have delivered). The array of `excludePatterns` comes from existing code in [the `email-delivery` integration](https://github.com/activeprospect/leadconduit-integration-email-delivery/blob/master/lib/send.js#L157-L175).